### PR TITLE
Add a research tree load type option: Do not generate research tree, but keep research queue

### DIFF
--- a/Languages/ChineseSimplified/Keyed/KeyedTranslations.xml
+++ b/Languages/ChineseSimplified/Keyed/KeyedTranslations.xml
@@ -36,6 +36,7 @@
   <Fluffy.ResearchTree.LoadTypeOne>游戏加载过程中</Fluffy.ResearchTree.LoadTypeOne>
   <Fluffy.ResearchTree.LoadTypeTwo>游戏在后台加载后</Fluffy.ResearchTree.LoadTypeTwo>
   <Fluffy.ResearchTree.LoadTypeThree>首次打开研究树</Fluffy.ResearchTree.LoadTypeThree>
+  <Fluffy.ResearchTree.LoadTypeFour>不生成研究树，但保留研究队列</Fluffy.ResearchTree.LoadTypeFour>
   <Fluffy.ResearchTree.PreparingTree.LayoutNew>最终确定研究树布局</Fluffy.ResearchTree.PreparingTree.LayoutNew>
   <Fluffy.ResearchTree.VanillaGraphics>使用旧的图形方法（如果闪烁）</Fluffy.ResearchTree.VanillaGraphics>
   <Fluffy.ResearchTree.ShowCompletion>研究完成后弹出完成对话框</Fluffy.ResearchTree.ShowCompletion>

--- a/Languages/English/Keyed/KeyedTranslations.xml
+++ b/Languages/English/Keyed/KeyedTranslations.xml
@@ -41,6 +41,7 @@
   <Fluffy.ResearchTree.LoadTypeOne>During game load</Fluffy.ResearchTree.LoadTypeOne>
   <Fluffy.ResearchTree.LoadTypeTwo>After game load in background</Fluffy.ResearchTree.LoadTypeTwo>
   <Fluffy.ResearchTree.LoadTypeThree>First time opening research-tree</Fluffy.ResearchTree.LoadTypeThree>
+  <Fluffy.ResearchTree.LoadTypeFour>Do not generate research tree, but keep research queue</Fluffy.ResearchTree.LoadTypeFour>
   <Fluffy.ResearchTree.QueuedNode>Already queued node</Fluffy.ResearchTree.QueuedNode>
   <Fluffy.ResearchTree.MissingFacilities>Missing {0}</Fluffy.ResearchTree.MissingFacilities>
   <Fluffy.ResearchTree.MissingTechprints>Insufficient techprints {0}/{1}</Fluffy.ResearchTree.MissingTechprints>

--- a/Languages/French/Keyed/KeyedTranslations.xml
+++ b/Languages/French/Keyed/KeyedTranslations.xml
@@ -36,6 +36,7 @@
   <Fluffy.ResearchTree.LoadTypeOne>Pendant le chargement du jeu</Fluffy.ResearchTree.LoadTypeOne>
   <Fluffy.ResearchTree.LoadTypeTwo>Après le chargement du jeu en arrière-plan</Fluffy.ResearchTree.LoadTypeTwo>
   <Fluffy.ResearchTree.LoadTypeThree>Première ouverture de l'arbre de recherche</Fluffy.ResearchTree.LoadTypeThree>
+  <Fluffy.ResearchTree.LoadTypeFour>Ne pas générer d'arbre de recherche, mais conserver la file d'attente de recherche</Fluffy.ResearchTree.LoadTypeFour>
   <Fluffy.ResearchTree.PreparingTree.LayoutNew>Finalisation de la présentation de l'arbre de recherche</Fluffy.ResearchTree.PreparingTree.LayoutNew>
   <Fluffy.ResearchTree.VanillaGraphics>Utiliser les anciennes méthodes graphiques (en cas de scintillement)</Fluffy.ResearchTree.VanillaGraphics>
   <Fluffy.ResearchTree.ShowCompletion>Afficher un message d'achèvement pour les recherches terminées</Fluffy.ResearchTree.ShowCompletion>

--- a/Languages/German/Keyed/KeyedTranslations.xml
+++ b/Languages/German/Keyed/KeyedTranslations.xml
@@ -37,6 +37,7 @@
   <Fluffy.ResearchTree.LoadTypeOne>Beim Laden des Spiels</Fluffy.ResearchTree.LoadTypeOne>
   <Fluffy.ResearchTree.LoadTypeTwo>Nach dem Laden des Spiels im Hintergrund</Fluffy.ResearchTree.LoadTypeTwo>
   <Fluffy.ResearchTree.LoadTypeThree>Erstmaliges Öffnen des Forschungsbaums</Fluffy.ResearchTree.LoadTypeThree>
+  <Fluffy.ResearchTree.LoadTypeFour>Keinen Forschungsbaum generieren, aber Forschungswarteschlange behalten</Fluffy.ResearchTree.LoadTypeFour>
   <Fluffy.ResearchTree.PreparingTree.LayoutNew>Fertigstellung des Layouts des Forschungsbaums</Fluffy.ResearchTree.PreparingTree.LayoutNew>
   <Fluffy.ResearchTree.VanillaGraphics>Verwenden Sie die alten grafischen Methoden (bei Flackern)</Fluffy.ResearchTree.VanillaGraphics>
   <Fluffy.ResearchTree.ShowCompletion>Abschlussmeldung für beendete Recherchen anzeigen</Fluffy.ResearchTree.ShowCompletion>

--- a/Languages/Russian/Keyed/KeyedTranslations.xml
+++ b/Languages/Russian/Keyed/KeyedTranslations.xml
@@ -26,6 +26,7 @@
   <Fluffy.ResearchTree.LoadTypeOne>   Во время загрузки игры</Fluffy.ResearchTree.LoadTypeOne>
   <Fluffy.ResearchTree.LoadTypeTwo>   После загрузки игры в фоновом режиме</Fluffy.ResearchTree.LoadTypeTwo>
   <Fluffy.ResearchTree.LoadTypeThree> Первое открытие дерева исследований</Fluffy.ResearchTree.LoadTypeThree>
+  <Fluffy.ResearchTree.LoadTypeFour>Не создавать дерево исследований, но сохранять очередь исследований</Fluffy.ResearchTree.LoadTypeFour>
   <Fluffy.ResearchTree.QueuedNode>Уже в очереди</Fluffy.ResearchTree.QueuedNode>
   <Fluffy.ResearchTree.MissingFacilities>Отсутствует {0}</Fluffy.ResearchTree.MissingFacilities>
   <Fluffy.ResearchTree.MissingTechprints>Недостаточно технологических отпечатков {0}/{1}</Fluffy.ResearchTree.MissingTechprints>

--- a/Languages/Spanish/Keyed/KeyedTranslations.xml
+++ b/Languages/Spanish/Keyed/KeyedTranslations.xml
@@ -35,6 +35,7 @@
   <Fluffy.ResearchTree.LoadTypeOne>Durante la carga del juego</Fluffy.ResearchTree.LoadTypeOne>
   <Fluffy.ResearchTree.LoadTypeTwo>Después de la carga del juego en segundo plano</Fluffy.ResearchTree.LoadTypeTwo>
   <Fluffy.ResearchTree.LoadTypeThree>La primera vez que se abre el árbol de investigación</Fluffy.ResearchTree.LoadTypeThree>
+  <Fluffy.ResearchTree.LoadTypeFour>No generar árbol de investigación, pero mantener cola de investigación</Fluffy.ResearchTree.LoadTypeFour>
   <Fluffy.ResearchTree.QueuedNode>Nodo ya en cola</Fluffy.ResearchTree.QueuedNode>
   <Fluffy.ResearchTree.MissingFacilities>Faltan {0}</Fluffy.ResearchTree.MissingFacilities>
   <Fluffy.ResearchTree.MissingTechprints>Faltan planos {0}/{1}</Fluffy.ResearchTree.MissingTechprints>

--- a/Languages/SpanishLatin/Keyed/KeyedTranslations.xml
+++ b/Languages/SpanishLatin/Keyed/KeyedTranslations.xml
@@ -34,6 +34,7 @@
   <Fluffy.ResearchTree.LoadType>¿Cuándo debe generarse el árbol de investigación?</Fluffy.ResearchTree.LoadType>
   <Fluffy.ResearchTree.LoadTypeOne>Durante la carga del juego</Fluffy.ResearchTree.LoadTypeOne>
   <Fluffy.ResearchTree.LoadTypeTwo>Después de la carga del juego en segundo plano</Fluffy.ResearchTree.LoadTypeTwo>
+  <Fluffy.ResearchTree.LoadTypeFour>No generar árbol de investigación, pero mantener cola de investigación</Fluffy.ResearchTree.LoadTypeFour>
   <Fluffy.ResearchTree.LoadTypeThree>La primera vez que se abre el árbol de investigación</Fluffy.ResearchTree.LoadTypeThree>
   <Fluffy.ResearchTree.QueuedNode>Nodo ya en cola</Fluffy.ResearchTree.QueuedNode>
   <Fluffy.ResearchTree.MissingFacilities>Faltan {0}</Fluffy.ResearchTree.MissingFacilities>

--- a/Source/ResearchTree/Assets.cs
+++ b/Source/ResearchTree/Assets.cs
@@ -344,7 +344,7 @@ public static class Assets
             ColorUnavailable[relevantTechLevels[i]] = Color.HSVToRGB(1f / count * i, 0.125f, 0.33f);
         }
 
-        if (FluffyResearchTreeMod.instance.Settings.LoadType == 1)
+        if (FluffyResearchTreeMod.instance.Settings.LoadType == Constants.LoadTypeLoadInBackground)
         {
             LongEventHandler.QueueLongEvent(StartLoadingWorker, "ResearchPal.BuildingResearchTreeAsync", true, null);
         }

--- a/Source/ResearchTree/Constants.cs
+++ b/Source/ResearchTree/Constants.cs
@@ -26,6 +26,10 @@ public static class Constants
     public const int LeftClick = 0;
 
     public const int RightClick = 1;
+    
+    public const int LoadTypeLoadInBackground = 1;
+    public const int LoadTypeFirstTimeOpening = 2;
+    public const int LoadTypeDoNotGenerateResearchTree = 3;
 
     public static readonly Vector2 IconSize = new Vector2(18f, 18f);
 

--- a/Source/ResearchTree/Extensions/ResearchProjectDef_Extensions.cs
+++ b/Source/ResearchTree/Extensions/ResearchProjectDef_Extensions.cs
@@ -175,7 +175,7 @@ public static class ResearchProjectDef_Extensions
             return null;
         }
 
-        var researchNode = Tree.ResearchToNodesCache.TryGetValue(research) as ResearchNode;
+        var researchNode = Tree.ResearchToNode(research) as ResearchNode;
         if (researchNode == null)
         {
             // It would be better to use warning instead of error. This is just a reminder.

--- a/Source/ResearchTree/FluffyResearchTreeMod.cs
+++ b/Source/ResearchTree/FluffyResearchTreeMod.cs
@@ -52,17 +52,26 @@ internal class FluffyResearchTreeMod : Mod
         listing_Standard.Gap();
         listing_Standard.Label("Fluffy.ResearchTree.LoadType".Translate());
 
-        if (listing_Standard.RadioButton("Fluffy.ResearchTree.LoadTypeTwo".Translate(), Settings.LoadType == 1))
+        if (listing_Standard.RadioButton("Fluffy.ResearchTree.LoadTypeTwo".Translate(), Settings.LoadType == Constants.LoadTypeLoadInBackground))
         {
-            Settings.LoadType = 1;
+            Settings.LoadType = Constants.LoadTypeLoadInBackground;
         }
 
-        if (listing_Standard.RadioButton("Fluffy.ResearchTree.LoadTypeThree".Translate(), Settings.LoadType == 2))
+        if (listing_Standard.RadioButton("Fluffy.ResearchTree.LoadTypeThree".Translate(), Settings.LoadType == Constants.LoadTypeFirstTimeOpening))
         {
-            Settings.LoadType = 2;
+            Settings.LoadType = Constants.LoadTypeFirstTimeOpening;
         }
 
-        if (Settings.LoadType == 1 && Prefs.UIScale > 1f)
+        if (!Settings.OverrideResearch)
+        {
+            if (listing_Standard.RadioButton("Fluffy.ResearchTree.LoadTypeFour".Translate(), Settings.LoadType == Constants.LoadTypeDoNotGenerateResearchTree))
+            {
+                Settings.LoadType = Constants.LoadTypeDoNotGenerateResearchTree;
+                Settings.OverrideResearch = false;
+            }
+        }
+
+        if (Settings.LoadType == Constants.LoadTypeLoadInBackground && Prefs.UIScale > 1f)
         {
             listing_Standard.Label("Fluffy.ResearchTree.UIScaleWarning".Translate());
         }
@@ -80,8 +89,10 @@ internal class FluffyResearchTreeMod : Mod
         }
 
         listing_Standard.Gap();
-        listing_Standard.CheckboxLabeled("Fluffy.ResearchTree.OverrideResearch".Translate(),
-            ref Settings.OverrideResearch);
+        if (Settings.LoadType != Constants.LoadTypeDoNotGenerateResearchTree)
+        {
+            listing_Standard.CheckboxLabeled("Fluffy.ResearchTree.OverrideResearch".Translate(), ref Settings.OverrideResearch);
+        }
         listing_Standard.CheckboxLabeled("Fluffy.ResearchTree.PauseOnOpen".Translate(), ref Settings.PauseOnOpen);
         listing_Standard.CheckboxLabeled("Fluffy.ResearchTree.ShowCompletion".Translate(), ref Settings.ShowCompletion);
         if (ModsConfig.IdeologyActive)

--- a/Source/ResearchTree/FluffyResearchTreeSettings.cs
+++ b/Source/ResearchTree/FluffyResearchTreeSettings.cs
@@ -10,7 +10,7 @@ internal class FluffyResearchTreeSettings : ModSettings
 {
     public Color BackgroundColor = new Color(0f, 0f, 0f, 0.1f);
     public bool CtrlFunction = true;
-    public int LoadType = 1;
+    public int LoadType = Constants.LoadTypeLoadInBackground;
     public bool NoIdeologyPopup;
     public bool OverrideResearch = true;
     public bool PauseOnOpen = true;
@@ -43,7 +43,7 @@ internal class FluffyResearchTreeSettings : ModSettings
         ShowCompletion = false;
         NoIdeologyPopup = false;
         VerboseLogging = false;
-        LoadType = 1;
+        LoadType = Constants.LoadTypeLoadInBackground;
         BackgroundColor = new Color(0f, 0f, 0f, 0.1f);
     }
 }

--- a/Source/ResearchTree/Patches/MainButtonWorker_DoButton.cs
+++ b/Source/ResearchTree/Patches/MainButtonWorker_DoButton.cs
@@ -17,6 +17,11 @@ public class MainButtonWorker_DoButton
 
         Queue.DrawLabelForMainButton(rect);
 
+        if (FluffyResearchTreeMod.instance.Settings.LoadType == Constants.LoadTypeDoNotGenerateResearchTree)
+        {
+            return;
+        }
+
         TooltipHandler.TipRegion(rect,
             FluffyResearchTreeMod.instance.Settings.OverrideResearch
                 ? "Fluffy.ResearchTree.HoldForClassic".Translate()

--- a/Source/ResearchTree/Patches/MainTabsRoot_ToggleTab.cs
+++ b/Source/ResearchTree/Patches/MainTabsRoot_ToggleTab.cs
@@ -31,6 +31,11 @@ public class MainTabsRoot_ToggleTab
         {
             newTab = Assets.OrganizedResearchTab;
         }
+        
+        if (FluffyResearchTreeMod.instance.Settings.LoadType == Constants.LoadTypeDoNotGenerateResearchTree)
+        {
+            return;
+        }
 
         switch (FluffyResearchTreeMod.instance.Settings.OverrideResearch)
         {

--- a/Source/ResearchTree/Patches/SemiRandomResearch_DrawGoToTechTreeButton.cs
+++ b/Source/ResearchTree/Patches/SemiRandomResearch_DrawGoToTechTreeButton.cs
@@ -32,15 +32,19 @@ public static class SemiRandomResearch_DrawGoToTechTreeButton
         Find.WindowStack.TryRemove(mainTabWindow, false);
         var researchTab = MainButtonDefOf.Research;
         ((MainTabWindow_Research)MainButtonDefOf.Research.TabWindow).CurTab = ResearchTabDefOf.Main;
-        switch (FluffyResearchTreeMod.instance.Settings.OverrideResearch)
+        
+        if (FluffyResearchTreeMod.instance.Settings.LoadType != Constants.LoadTypeDoNotGenerateResearchTree)
         {
-            // LeftCtrl is the way of Dubs Mint Menus mod
-            case true when
-                !Input.GetKey(KeyCode.LeftShift) && !Input.GetKey(KeyCode.LeftControl):
-            case false when
-                Input.GetKey(KeyCode.LeftShift) && !Input.GetKey(KeyCode.LeftControl):
-                researchTab = Assets.MainButtonDefOf.FluffyResearchTree;
-                break;
+            switch (FluffyResearchTreeMod.instance.Settings.OverrideResearch)
+            {
+                // LeftCtrl is the way of Dubs Mint Menus mod
+                case true when
+                    !Input.GetKey(KeyCode.LeftShift) && !Input.GetKey(KeyCode.LeftControl):
+                case false when
+                    Input.GetKey(KeyCode.LeftShift) && !Input.GetKey(KeyCode.LeftControl):
+                    researchTab = Assets.MainButtonDefOf.FluffyResearchTree;
+                    break;
+            }
         }
 
         Find.WindowStack.Add(researchTab.TabWindow);

--- a/Source/ResearchTree/Queue.cs
+++ b/Source/ResearchTree/Queue.cs
@@ -326,8 +326,8 @@ public class Queue : WorldComponent
     public static void DrawLabelForMainButton(Rect rect)
     {
         var currentStart = rect.xMax - Constants.SmallQueueLabelSize - Constants.Margin;
-        if (!Tree.Initialized && FluffyResearchTreeMod.instance.Settings.LoadType != 2 &&
-            FluffyResearchTreeMod.instance.Settings.OverrideResearch)
+        if (!Tree.Initialized && FluffyResearchTreeMod.instance.Settings.LoadType != Constants.LoadTypeFirstTimeOpening 
+                              && FluffyResearchTreeMod.instance.Settings.OverrideResearch)
         {
             DrawLabel(
                 new Rect(currentStart, 0f, Constants.SmallQueueLabelSize, Constants.SmallQueueLabelSize)

--- a/Source/ResearchTree/ResearchNode.cs
+++ b/Source/ResearchTree/ResearchNode.cs
@@ -13,11 +13,9 @@ namespace FluffyResearchTree;
 
 public class ResearchNode : Node
 {
-    private static readonly Dictionary<ResearchProjectDef, bool> _buildingPresentCache =
-        new Dictionary<ResearchProjectDef, bool>();
+    private static readonly Dictionary<ResearchProjectDef, bool> _buildingPresentCache = new();
 
-    private static readonly Dictionary<ResearchProjectDef, List<ThingDef>> _missingFacilitiesCache =
-        new Dictionary<ResearchProjectDef, List<ThingDef>>();
+    private static readonly Dictionary<ResearchProjectDef, List<ThingDef>> _missingFacilitiesCache = new();
 
     private readonly int cacheOrder;
 
@@ -115,7 +113,8 @@ public class ResearchNode : Node
                 return false;
             }
 
-            return DebugSettings.godMode || getCacheValue();
+            return FluffyResearchTreeMod.instance.Settings.LoadType == Constants.LoadTypeDoNotGenerateResearchTree 
+                   || DebugSettings.godMode || getCacheValue();
         }
     }
 

--- a/Source/ResearchTree/Tree.cs
+++ b/Source/ResearchTree/Tree.cs
@@ -30,8 +30,7 @@ public static class Tree
 
     public static bool FirstLoadDone;
 
-    public static readonly Dictionary<ResearchProjectDef, Node> ResearchToNodesCache =
-        new Dictionary<ResearchProjectDef, Node>();
+    public static readonly Dictionary<ResearchProjectDef, Node> ResearchToNodesCache = new();
 
     public static Dictionary<TechLevel, IntRange> TechLevelBounds
     {
@@ -88,7 +87,18 @@ public static class Tree
             return null;
         }
     }
-
+    
+    public static Node ResearchToNode(ResearchProjectDef research)
+    {
+        var node = ResearchToNodesCache.TryGetValue(research);
+        if (node != null)
+        {
+            return node;
+        }
+        PopulateNodes();
+        return ResearchToNodesCache.TryGetValue(research);
+    }
+    
     public static void Reset(bool alsoZoom)
     {
         Messages.Message("Fluffy.ResearchTree.ResolutionChange".Translate(), MessageTypeDefOf.NeutralEvent);
@@ -114,7 +124,7 @@ public static class Tree
             MainTabWindow_ResearchTree.Instance.ViewRectDirty = true;
         }
 
-        if (FluffyResearchTreeMod.instance.Settings.LoadType == 1)
+        if (FluffyResearchTreeMod.instance.Settings.LoadType == Constants.LoadTypeLoadInBackground)
         {
             LongEventHandler.QueueLongEvent(Assets.StartLoadingWorker, "ResearchPal.BuildingResearchTreeAsync", true,
                 null);
@@ -123,14 +133,15 @@ public static class Tree
 
     public static void Initialize()
     {
-        if (Initialized || _initializing)
+        if (FluffyResearchTreeMod.instance?.Settings?.LoadType == Constants.LoadTypeDoNotGenerateResearchTree 
+            || Initialized || _initializing)
         {
             return;
         }
 
         _initializing = true;
 
-        if (FluffyResearchTreeMod.instance?.Settings?.LoadType == 1)
+        if (FluffyResearchTreeMod.instance?.Settings?.LoadType == Constants.LoadTypeLoadInBackground)
         {
             try
             {
@@ -414,7 +425,7 @@ public static class Tree
         }
     }
 
-    public static void HorizontalPositions()
+    private static void HorizontalPositions()
     {
         var relevantTechLevels = RelevantTechLevels;
         var num = 1;


### PR DESCRIPTION
This option is displayed only if the OverrideResearch checkbox is disabled.
It disables the initialization of the research tree and the display of the research tree window, leaving only the research queue functionality. 
This allows you to queue research in the vanilla research window by Ctrl/Shift + Left/Right Click.